### PR TITLE
Fix NoMethodError on bin/scylla

### DIFF
--- a/bin/scylla
+++ b/bin/scylla
@@ -9,5 +9,5 @@ while(phrase != "exit")
   puts "Phrase:"
   STDOUT.flush
   phrase = gets.chomp
-  puts phrase.guess.join(" or ")
+  puts phrase.guess_language.join(" or ")
 end


### PR DESCRIPTION
Gem version : 1.1.0
---
Hi, when testing Scylla gem, running the `./bin/scylla` fails. You probably forgot to change the method call when changed the method name.

## To reproduce it : 
I have no idea how to create a automated test for that.

```
$ ./bin/scylla
Welcome to Scylla Language Guesser
Enter a phrase which you would like to identify
Type exit to quit
Phrase:
salut
./bin/scylla:12:in `<main>': undefined method `guess' for "salut":String (NoMethodError)
```